### PR TITLE
Fix CounterCache interoperability, improve event configuration handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
         "source": "https://github.com/usemuffin/trash"
     },
     "require": {
-        "cakephp/cakephp": "~3.0"
+        "cakephp/cakephp": "^3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -24,11 +24,14 @@ class TrashBehavior extends Behavior
      * Default configuration.
      *
      * - field: the name of the datetime field to use for tracking `trashed` records.
+     * - priority: the default priority for events
+     * - events: the list of events to enable (also accepts arrays in `implementedEvents()`-compatible format)
      *
      * @var array
      */
     protected $_defaultConfig = [
         'field' => null,
+        'priority' => null,
         'events' => [
             'Model.beforeDelete',
             'Model.beforeFind',
@@ -75,6 +78,9 @@ class TrashBehavior extends Behavior
     public function implementedEvents()
     {
         $events = [];
+        if ($this->config('events') === false) {
+            return $events;
+        }
         foreach ((array)$this->config('events') as $eventKey => $event) {
             if (is_numeric($eventKey)) {
                 $eventKey = $event;
@@ -140,7 +146,7 @@ class TrashBehavior extends Behavior
         }
 
         return (bool)$this->_table->updateAll(
-            [$this->getTrashField(false) => new Time()],
+            [$field => new Time()],
             [$primaryKey => $entity->{$primaryKey}]
         );
     }

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -64,7 +64,7 @@ class TrashBehavior extends Behavior
 
         parent::__construct($table, $config);
 
-        if (array_key_exists('events', $config)) {
+        if (!empty($config['events'])) {
             $this->config('events', $config['events'], false);
         }
     }

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -92,7 +92,14 @@ class TrashBehavior extends Behavior
         if (!$this->trash($entity)) {
             throw new RuntimeException();
         }
+
         $event->stopPropagation();
+
+        $event->subject()->dispatchEvent('Model.afterDelete', [
+            'entity' => $entity,
+            'options' => $options
+        ]);
+
         return true;
     }
 

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -5,10 +5,10 @@ use ArrayObject;
 use Cake\Core\Configure;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\UnaryExpression;
+use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior;
-use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use RuntimeException;
@@ -81,13 +81,13 @@ class TrashBehavior extends Behavior
     /**
      * Callback to never really delete a record but instead mark it as `trashed`.
      *
-     * @param \Cake\Event\Event $event Event.
-     * @param \Cake\ORM\Entity $entity Entity.
+     * @param \Cake\Event\Event $event The beforeDelete event that was fired.
+     * @param \Cake\Datasource\EntityInterface $entity The entity to be deleted.
      * @param \ArrayObject $options Options.
      * @return true
      * @throws \RuntimeException if fails to mark entity as `trashed`.
      */
-    public function beforeDelete(Event $event, Entity $entity, ArrayObject $options)
+    public function beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         if (!$this->trash($entity)) {
             throw new RuntimeException();
@@ -99,11 +99,11 @@ class TrashBehavior extends Behavior
     /**
      * Trash given entity.
      *
-     * @param \Cake\ORM\Entity $entity Entity.
+     * @param \Cake\Datasource\EntityInterface $entity EntityInterface.
      * @return bool
      * @throws \RuntimeException if no primary key is set on entity.
      */
-    public function trash(Entity $entity)
+    public function trash(EntityInterface $entity)
     {
         $field = $this->getTrashField(false);
         $primaryKey = $this->_table->primaryKey();
@@ -200,14 +200,14 @@ class TrashBehavior extends Behavior
     /**
      * Restores all (or given) trashed row(s).
      *
-     * @param \Cake\ORM\Entity|null $entity to restore.
-     * @return bool|\Cake\Datasource\EntityInterface|int
+     * @param \Cake\Datasource\EntityInterface|null $entity to restore.
+     * @return bool|\Cake\Datasource\EntityInterface|int|mixed
      */
-    public function restoreTrash(Entity $entity = null)
+    public function restoreTrash(EntityInterface $entity = null)
     {
         $data = [$this->getTrashField(false) => null];
 
-        if ($entity instanceof Entity) {
+        if ($entity instanceof EntityInterface) {
             if ($entity->dirty()) {
                 throw new RuntimeException('Can not restore from a dirty entity.');
             }

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -1,6 +1,7 @@
 <?php
 namespace Muffin\Trash\Test\Fixture;
 
+use Cake\I18n\Time;
 use Cake\TestSuite\Fixture\TestFixture;
 
 class ArticlesFixture extends TestFixture
@@ -16,6 +17,8 @@ class ArticlesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'null' => false],
         'sub_title' => ['type' => 'string', 'null' => false],
+        'comment_count' => ['type' => 'integer', 'null' => true],
+        'total_comment_count' => ['type' => 'integer', 'null' => true],
         'trashed' => ['type' => 'datetime', 'null' => true],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],
@@ -35,7 +38,7 @@ class ArticlesFixture extends TestFixture
 
     public function init()
     {
-        $created = $modified = date('Y-m-d H:i:s');
+        $created = $modified = new Time();
         array_walk($this->records, function (&$record) use ($created, $modified) {
             $record += compact('created', 'modified');
         });

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -4,10 +4,21 @@ namespace Muffin\Trash\Test\TestCase\Model\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Muffin\Trash\Model\Behavior\TrashBehavior;
 
+/**
+ * @property \Cake\ORM\Table Users
+ * @property \Cake\ORM\Table Comments
+ * @property \Cake\ORM\Table Articles
+ * @property \Muffin\Trash\Model\Behavior\TrashBehavior Behavior
+ */
 class TrashBehaviorTest extends TestCase
 {
-
+    /**
+     * Fixtures to load.
+     *
+     * @var array
+     */
     public $fixtures = [
         'plugin.Muffin/Trash.articles',
         'plugin.Muffin/Trash.comments',
@@ -15,6 +26,11 @@ class TrashBehaviorTest extends TestCase
         'plugin.Muffin/Trash.articles_users',
     ];
 
+    /**
+     * Runs before each test.
+     *
+     * @return void
+     */
     public function setUp()
     {
         parent::setUp();
@@ -54,19 +70,34 @@ class TrashBehaviorTest extends TestCase
         $this->Behavior = $this->Articles->behaviors()->Trash;
     }
 
+    /**
+     * Runs after each test.
+     *
+     * @return void
+     */
     public function tearDown()
     {
         parent::tearDown();
         TableRegistry::clear();
-        unset($this->Articles, $this->Behavior);
+        unset($this->Users, $this->Comments, $this->Articles, $this->Behavior);
     }
 
+    /**
+     * Test the beforeFind callback.
+     *
+     * @return void
+     */
     public function testBeforeFind()
     {
         $result = $this->Articles->find('all')->toArray();
         $this->assertCount(1, $result);
     }
 
+    /**
+     * Test the beforeDelete callback.
+     *
+     * @return void
+     */
     public function testBeforeDelete()
     {
         $article = $this->Articles->get(1);
@@ -76,16 +107,31 @@ class TrashBehaviorTest extends TestCase
         $this->assertCount(3, $this->Articles->find('withTrashed'));
     }
 
+    /**
+     * Test it can find only trashed records.
+     *
+     * @return void
+     */
     public function testFindOnlyTrashed()
     {
         $this->assertCount(2, $this->Articles->find('onlyTrashed'));
     }
 
+    /**
+     * Test it can find with trashed records.
+     *
+     * @return void
+     */
     public function testFindWithTrashed()
     {
         $this->assertCount(3, $this->Articles->find('withTrashed'));
     }
 
+    /**
+     * Test it can empty all records from the trash.
+     *
+     * @return void
+     */
     public function testEmptyTrash()
     {
         $this->Articles->emptyTrash();
@@ -93,6 +139,11 @@ class TrashBehaviorTest extends TestCase
         $this->assertCount(1, $this->Articles->find());
     }
 
+    /**
+     * Test it can restore all records in the trash.
+     *
+     * @return void
+     */
     public function testRestoreTrash()
     {
         $this->Articles->restoreTrash();
@@ -100,6 +151,11 @@ class TrashBehaviorTest extends TestCase
         $this->assertCount(3, $this->Articles->find());
     }
 
+    /**
+     * Test it can trash all records.
+     *
+     * @return void
+     */
     public function testTrashAll()
     {
         $this->assertCount(1, $this->Articles->find());
@@ -108,6 +164,11 @@ class TrashBehaviorTest extends TestCase
         $this->assertCount(0, $this->Articles->find());
     }
 
+    /**
+     * Test it can restore one record from the trash.
+     *
+     * @return void
+     */
     public function testRestoreTrashEntity()
     {
         $this->Articles->restoreTrash(new Entity([
@@ -117,18 +178,33 @@ class TrashBehaviorTest extends TestCase
         $this->assertCount(2, $this->Articles->find());
     }
 
+    /**
+     * Test it can find records with a hasMany association.
+     *
+     * @return void
+     */
     public function testFindingRecordWithHasManyAssoc()
     {
         $result = $this->Articles->get(1, ['contain' => ['Comments']]);
         $this->assertCount(1, $result->comments);
     }
 
+    /**
+     * Test it can find records with HABTM association.
+     *
+     * @return void
+     */
     public function testFindingRecordWithBelongsToManyAssoc()
     {
         $result = $this->Users->get(1, ['contain' => ['Articles']]);
         $this->assertCount(1, $result->articles);
     }
 
+    /**
+     * Test that it can work alongside CounterCache behavior.
+     *
+     * @return void
+     */
     public function testInteroperabilityWithCounterCache()
     {
         $comment = $this->Comments->get(1);
@@ -137,5 +213,131 @@ class TrashBehaviorTest extends TestCase
 
         $this->assertEquals(0, $result->comment_count);
         $this->assertEquals(2, $result->total_comment_count);
+    }
+
+    /**
+     * Test the implementedEvents method.
+     *
+     * @dataProvider provideConfigsForImplementedEventsTest
+     * @param array $config Initial behavior config.
+     * @param array $implementedEvents Expected implementedEvents.
+     * @return void
+     */
+    public function testImplementedEvents(array $config, array $implementedEvents)
+    {
+        $trash = new TrashBehavior($this->Users, $config);
+
+        $this->assertEquals($implementedEvents, $trash->implementedEvents());
+    }
+
+    /**
+     * Provide configs for the implementedEvents test.
+     *
+     * @return array
+     */
+    public function provideConfigsForImplementedEventsTest()
+    {
+        return [
+            '@inheritDefaults' => [
+                '$config' => [],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => 'beforeDelete'
+                    ],
+                    'Model.beforeFind' => [
+                        'callable' => 'beforeFind'
+                    ],
+                ],
+            ],
+            '@disableDefaults' => [
+                '$config' => [
+                    'events' => [],
+                ],
+                '$implementedEvents' => [],
+            ],
+            '@numericArray' => [
+                '$config' => [
+                    'events' => [
+                        'Model.beforeDelete',
+                    ],
+                ],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => 'beforeDelete',
+                    ],
+                ],
+            ],
+            '@assocArray' => [
+                '$config' => [
+                    'events' => [
+                        'Model.beforeFind' => 'beforeFind',
+                    ],
+                ],
+                '$implementedEvents' => [
+                    'Model.beforeFind' => [
+                        'callable' => 'beforeFind'
+                    ],
+                ],
+            ],
+            '@callables' => [
+                '$config' => [
+                    'events' => [
+                        'Model.beforeDelete' => [
+                            'callable' => function () {
+                            },
+                        ],
+                        'Model.beforeFind' => [
+                            'callable' => [$this, 'beforeDelete'],
+                            'passParams' => true,
+                        ],
+                    ],
+                ],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => function () {
+                        }
+                    ],
+                    'Model.beforeFind' => [
+                        'callable' => [$this, 'beforeDelete'],
+                        'passParams' => true,
+                    ],
+                ],
+            ],
+            '@multipleParams' => [
+                '$config' => [
+                    'events' => [
+                        'Model.beforeDelete' => [
+                            'callable' => 'beforeDelete',
+                            'passParams' => true,
+                        ],
+                    ],
+                ],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => 'beforeDelete',
+                        'passParams' => true,
+                    ],
+                ],
+            ],
+            '@priority' => [
+                '$config' => [
+                    'priority' => 1,
+                    'events' => [
+                        'Model.beforeDelete',
+                        'Model.beforeFind' => ['priority' => 5],
+                    ],
+                ],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => 'beforeDelete',
+                        'priority' => 1,
+                    ],
+                    'Model.beforeFind' => [
+                        'callable' => 'beforeFind',
+                        'priority' => 5,
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -249,13 +249,20 @@ class TrashBehaviorTest extends TestCase
                     ],
                 ],
             ],
-            '@disableDefaultsWithFalse' => [
+            '@inheritDefaultsWhenEmptyArray' => [
                 '$config' => [
-                    'events' => false,
+                    'events' => [],
                 ],
-                '$implementedEvents' => [],
+                '$implementedEvents' => [
+                    'Model.beforeDelete' => [
+                        'callable' => 'beforeDelete'
+                    ],
+                    'Model.beforeFind' => [
+                        'callable' => 'beforeFind'
+                    ],
+                ],
             ],
-            '@disableDefaultsWithEmptyArray' => [
+            '@disableDefaultsWhenFalse' => [
                 '$config' => [
                     'events' => false,
                 ],

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -238,9 +238,9 @@ class TrashBehaviorTest extends TestCase
     public function provideConfigsForImplementedEventsTest()
     {
         return [
-            '@inheritDefaults' => [
-                '$config' => [],
-                '$implementedEvents' => [
+            'No event config inherits default events' => [
+                [],
+                [
                     'Model.beforeDelete' => [
                         'callable' => 'beforeDelete'
                     ],
@@ -249,11 +249,11 @@ class TrashBehaviorTest extends TestCase
                     ],
                 ],
             ],
-            '@inheritDefaultsWhenEmptyArray' => [
-                '$config' => [
+            'Event config with empty array inherits default events' => [
+                [
                     'events' => [],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeDelete' => [
                         'callable' => 'beforeDelete'
                     ],
@@ -262,38 +262,38 @@ class TrashBehaviorTest extends TestCase
                     ],
                 ],
             ],
-            '@disableDefaultsWhenFalse' => [
-                '$config' => [
+            'Event config with false disables default events' => [
+                [
                     'events' => false,
                 ],
-                '$implementedEvents' => [],
+                [],
             ],
-            '@numericArray' => [
-                '$config' => [
+            'Event config with event key as value' => [
+                [
                     'events' => [
                         'Model.beforeDelete',
                     ],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeDelete' => [
                         'callable' => 'beforeDelete',
                     ],
                 ],
             ],
-            '@assocArray' => [
-                '$config' => [
+            'Event config with method name as value' => [
+                [
                     'events' => [
                         'Model.beforeFind' => 'beforeFind',
                     ],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeFind' => [
                         'callable' => 'beforeFind'
                     ],
                 ],
             ],
-            '@callables' => [
-                '$config' => [
+            'Event config with callables' => [
+                [
                     'events' => [
                         'Model.beforeDelete' => [
                             'callable' => function () {
@@ -305,7 +305,7 @@ class TrashBehaviorTest extends TestCase
                         ],
                     ],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeDelete' => [
                         'callable' => function () {
                         }
@@ -316,8 +316,8 @@ class TrashBehaviorTest extends TestCase
                     ],
                 ],
             ],
-            '@multipleParams' => [
-                '$config' => [
+            'Event config with multiple options' => [
+                [
                     'events' => [
                         'Model.beforeDelete' => [
                             'callable' => 'beforeDelete',
@@ -325,22 +325,22 @@ class TrashBehaviorTest extends TestCase
                         ],
                     ],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeDelete' => [
                         'callable' => 'beforeDelete',
                         'passParams' => true,
                     ],
                 ],
             ],
-            '@priority' => [
-                '$config' => [
+            'Event config with default and event priorities' => [
+                [
                     'priority' => 1,
                     'events' => [
                         'Model.beforeDelete',
                         'Model.beforeFind' => ['priority' => 5],
                     ],
                 ],
-                '$implementedEvents' => [
+                [
                     'Model.beforeDelete' => [
                         'callable' => 'beforeDelete',
                         'priority' => 1,

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -249,9 +249,15 @@ class TrashBehaviorTest extends TestCase
                     ],
                 ],
             ],
-            '@disableDefaults' => [
+            '@disableDefaultsWithFalse' => [
                 '$config' => [
-                    'events' => [],
+                    'events' => false,
+                ],
+                '$implementedEvents' => [],
+            ],
+            '@disableDefaultsWithEmptyArray' => [
+                '$config' => [
+                    'events' => false,
                 ],
                 '$implementedEvents' => [],
             ],


### PR DESCRIPTION
- [x] Dispatch `Model.afterDelete` event:

  `Table` doesn't dispatch `Model.afterDelete` if you stop `Model.beforeDelete`, so the behavior now dispatches `Model.afterDelete` itself.

 The core CounterCache behavior was affected so a test has been added to avoid regressions.

- [x] Handle the different 'event' formats you would expect (with support for a default priority value):

  For example, configuring behavior with a `priority` and short-hand `events` syntax:

  ```php
  ['priority' => 1, 'events' => ['Model.beforeDelete']]`
  ```

  Will result in the following (normalized) `implementedEvents()` return value:

  ```php
  ['Model.beforeDelete' => ['callable' => 'beforeDelete', 'priority' => 1]]
  ```

  