### PR TITLE
Fix trash function to be compatible with CounterCacheBehavior

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -138,17 +138,18 @@ class TrashBehavior extends Behavior
      */
     public function trash(EntityInterface $entity)
     {
-        $field = $this->getTrashField(false);
         $primaryKey = $this->_table->primaryKey();
 
         if (empty($entity->{$primaryKey})) {
             throw new RuntimeException();
         }
 
-        return (bool)$this->_table->updateAll(
-            [$field => new Time()],
-            [$primaryKey => $entity->{$primaryKey}]
-        );
+        $data = [$this->getTrashField(false) => new Time()];
+        $entity->set($data);
+        if ($this->_table->save($entity)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -106,6 +106,20 @@ class TrashBehaviorTest extends TestCase
         $this->assertTrue($result);
         $this->assertCount(3, $this->Articles->find('withTrashed'));
     }
+    
+    /**
+     * Test trash function
+     *
+     * @return void
+     */
+    public function testTrash()
+    {
+        $article = $this->Articles->get(1);
+        $result = $this->Articles->trash($article);
+
+        $this->assertTrue($result);
+        $this->assertCount(3, $this->Articles->find('withTrashed'));
+    }
 
     /**
      * Test it can find only trashed records.
@@ -209,6 +223,21 @@ class TrashBehaviorTest extends TestCase
     {
         $comment = $this->Comments->get(1);
         $this->Comments->delete($comment);
+        $result = $this->Articles->get(1);
+
+        $this->assertEquals(0, $result->comment_count);
+        $this->assertEquals(2, $result->total_comment_count);
+    }
+    
+    /**
+     * Test that it can work alongside CounterCache behavior and trash method.
+     *
+     * @return void
+     */
+    public function testInteroperabilityWithCounterCacheAndTrashMethod()
+    {
+        $comment = $this->Comments->get(1);
+        $this->Comments->trash($comment);
         $result = $this->Articles->get(1);
 
         $this->assertEquals(0, $result->comment_count);


### PR DESCRIPTION
This PR allows to combine Trash and CounterCache behavior over the same fields.

I detected while trying to use CounterCacheBehavior based in *deleted* trash field that when using *trash()* method counter caches are not updated, but *untrash()* method still updates counter caches.

Example
```php
// Tasks has a deleted DATETIME NULLS ALLOWED DEFAULT NULL field

// Tasks table initialize
$this->addBehavior('Muffin/Trash.Trash');
$this->addBehavior('CounterCache', [
            'Clients' => [
                'tasks_count_in_progress' => [
                    'conditions' => ['Tasks.deleted IS' => null]
                ],
                'tasks_count_completed' => [
                    'conditions' => ['Tasks.deleted IS NOT' => null]
                ],
            ],
        ]);
```