### PR TITLE
Update TrashBehavior to work when property is not accessible

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -145,7 +145,7 @@ class TrashBehavior extends Behavior
         }
 
         $data = [$this->getTrashField(false) => new Time()];
-        $entity->set($data);
+        $entity->set($data, ['guard' => false]);
         if ($this->_table->save($entity)) {
             return true;
         }
@@ -245,7 +245,7 @@ class TrashBehavior extends Behavior
             if ($entity->dirty()) {
                 throw new RuntimeException('Can not restore from a dirty entity.');
             }
-            $entity->set($data);
+            $entity->set($data, ['guard' => false]);
             return $this->_table->save($entity);
         }
 

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -129,7 +129,7 @@ class TrashBehaviorTest extends TestCase
     public function testTrashNonAccessibleProperty()
     {
         $article = $this->Articles->get(1);
-        $article->accesible('trashed', false);
+        $article->accessible('trashed', false);
         $result = $this->Articles->trash($article);
 
         $this->assertTrue($result);


### PR DESCRIPTION
When the TrashField property is not in `$_accessible` array in the entity, the `set()` method does nothing on that field - imo it should either give some kind of error, or just bypass the accessible.

In my case it doesn't make sense not just to bypass the non-accessible property.