### PR TITLE
Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ $this->addBehavior('Muffin/Trash.Trash', [
 ]);
 ```
 
+### Cascading deletion
+If you'd like to have related records marked as trashed when deleting a parent item, you can just attach the behavior 
+to the related table classes, and set the `'dependent' => true, 'cascadeCallbacks' => true` options in the table 
+relationships.
+
+This works on relationships where the item being deleted in the owning side of the relationship. Which means that the 
+related table should contain the foreign key.
+
 ### Custom Finders
 
 - **onlyTrashed** - helps getting only those trashed records.

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "cakephp/cakephp": "3.*"
+        "cakephp/cakephp": "3.*",
+        "cakephp/cakephp-codesniffer": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have created the functionality to allow the soft delete to cascade through related table classes where the behaviour is attached.

I've also added a `cascadingRestoreTrash()` so that the process can be reversed, and also added two new test cases for these.