### PR TITLE
Add test that covers trashing via the `replace` save strategy.

### DIFF
--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -2,7 +2,6 @@
 namespace Muffin\Trash\Test\TestCase\Model\Behavior;
 
 use Cake\Core\Configure;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
@@ -371,7 +370,7 @@ class TrashBehaviorTest extends TestCase
         $article->set('comments', []);
         $article->dirty('comments', true);
 
-        $this->assertInstanceOf(EntityInterface::class, $this->Articles->save($article));
+        $this->assertInstanceOf('Cake\Datasource\EntityInterface', $this->Articles->save($article));
 
         $article = $this->Articles
             ->find('withTrashed')

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -61,7 +61,8 @@ class TrashBehaviorTest extends TestCase
         $this->Articles->addBehavior('Muffin/Trash.Trash');
         $this->Articles->hasMany('Comments', [
             'className' => 'Muffin/Trash.Comments',
-            'foreignKey' => 'article_id'
+            'foreignKey' => 'article_id',
+            'sort' => ['Comments.id' => 'ASC'],
         ]);
         $this->Articles->belongsToMany('Users', [
             'className' => 'Muffin/Trash.Users',


### PR DESCRIPTION
This should also answer #8.