### PR TITLE
Add support for passing options into the cascading delete process.

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -99,7 +99,7 @@ class TrashBehavior extends Behavior
      */
     public function beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options)
     {
-        if (!$this->trash($entity, $options)) {
+        if (!$this->trash($entity, $options->getArrayCopy())) {
             throw new RuntimeException();
         }
 
@@ -117,15 +117,12 @@ class TrashBehavior extends Behavior
      * Trash given entity.
      *
      * @param \Cake\Datasource\EntityInterface $entity EntityInterface.
-     * @param array|\ArrayAccess $options Delete/Trash operation options.
+     * @param array $options Delete/Trash operation options.
      * @return bool
-     * @throws \InvalidArgumentException In case the options argument is of an invalid type.
      * @throws \RuntimeException if no primary key is set on entity.
      */
-    public function trash(EntityInterface $entity, $options = [])
+    public function trash(EntityInterface $entity, array $options = [])
     {
-        $options = new ArrayObject($options);
-
         $primaryKey = (array)$this->_table->primaryKey();
 
         if (!$entity->has($primaryKey)) {
@@ -134,7 +131,7 @@ class TrashBehavior extends Behavior
 
         foreach ($this->_table->associations() as $association) {
             if ($this->_isRecursable($association, $this->_table)) {
-                $association->cascadeDelete($entity, ['_primary' => false] + $options->getArrayCopy());
+                $association->cascadeDelete($entity, ['_primary' => false] + $options);
             }
         }
 

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -99,7 +99,7 @@ class TrashBehavior extends Behavior
      */
     public function beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options)
     {
-        if (!$this->trash($entity)) {
+        if (!$this->trash($entity, $options)) {
             throw new RuntimeException();
         }
 
@@ -117,11 +117,21 @@ class TrashBehavior extends Behavior
      * Trash given entity.
      *
      * @param \Cake\Datasource\EntityInterface $entity EntityInterface.
+     * @param array|\ArrayAccess $options Delete/Trash operation options.
      * @return bool
+     * @throws \InvalidArgumentException In case the options argument is of an invalid type.
      * @throws \RuntimeException if no primary key is set on entity.
      */
     public function trash(EntityInterface $entity)
     {
+        $args = func_get_args();
+        if (count($args) > 1) {
+            $options = $args[1];
+        } else {
+            $options = [];
+        }
+        $options = new ArrayObject($options);
+
         $primaryKey = (array)$this->_table->primaryKey();
 
         if (!$entity->has($primaryKey)) {
@@ -130,7 +140,7 @@ class TrashBehavior extends Behavior
 
         foreach ($this->_table->associations() as $association) {
             if ($this->_isRecursable($association, $this->_table)) {
-                $association->cascadeDelete($entity, ['_primary' => false]);
+                $association->cascadeDelete($entity, ['_primary' => false] + $options->getArrayCopy());
             }
         }
 

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -122,14 +122,8 @@ class TrashBehavior extends Behavior
      * @throws \InvalidArgumentException In case the options argument is of an invalid type.
      * @throws \RuntimeException if no primary key is set on entity.
      */
-    public function trash(EntityInterface $entity)
+    public function trash(EntityInterface $entity, $options = [])
     {
-        $args = func_get_args();
-        if (count($args) > 1) {
-            $options = $args[1];
-        } else {
-            $options = [];
-        }
         $options = new ArrayObject($options);
 
         $primaryKey = (array)$this->_table->primaryKey();

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -159,16 +159,6 @@ class TrashBehaviorTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Passed variable is not an array or object
-     */
-    public function testTrashInvalidOptionsType()
-    {
-        $article = $this->Articles->get(1);
-        $result = $this->Articles->trash($article, 'invalid');
-    }
-
-    /**
      * Test trash function with composite primary keys
      *
      * @return void


### PR DESCRIPTION
Something to get started with.

This should help with possible problems around missing options in the cascading delete process, and with manually handing over options into the saving process in case required, and not applicable to do so by the plugin itself.

refs #23