### PR TITLE
Skip beforeFind when field is used in a where clause

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -3,6 +3,7 @@ namespace Muffin\Trash\Model\Behavior;
 
 use ArrayObject;
 use Cake\Core\Configure;
+use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\UnaryExpression;
 use Cake\Datasource\EntityInterface;
@@ -167,6 +168,13 @@ class TrashBehavior extends Behavior
             if ($found === false
                 && $expression instanceof IdentifierExpression
                 && $expression->getIdentifier() === $field
+            ) {
+                $found = true;
+            }
+
+            if ($found === false
+                && $expression instanceof Comparison
+                && $expression->getField() === $field
             ) {
                 $found = true;
             }

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -4,6 +4,7 @@ namespace Muffin\Trash\Test\TestCase\Model\Behavior;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\I18n\Time;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
@@ -105,6 +106,20 @@ class TrashBehaviorTest extends TestCase
     {
         $result = $this->Articles->find('all')->toArray();
         $this->assertCount(1, $result);
+    }
+
+    /**
+     * Test the beforeFind callback when using the trash field
+     *
+     * @return void
+     */
+    public function testBeforeFindWithTrashField()
+    {
+        $query = $this->Articles->find('all');
+        $result = $query->where(
+            [$this->Articles->aliasField('trashed') . ' >= ' => '2000-01-01 00:00:00']
+        )->toArray();
+        $this->assertCount(2, $result);
     }
 
     /**


### PR DESCRIPTION
This PR extends the `beforeFind` listener so that the where clause is not automatically added, when the trashed field has been already used in the where clause. This is applicable when we define search queries using the trashed field in a comparison format

``` php
$query->where(
    [$this->Articles->aliasField('trashed') . ' >= ' => '2000-01-01 00:00:00']
)
```