### PR TITLE
Changed withTrashed finder to use options instead

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -184,7 +184,9 @@ class TrashBehavior extends Behavior
             }
         });
 
-        if ($addCondition) {
+        $option = $query->getOptions();
+
+        if ($addCondition && empty($option['skipAddTrashCondition'])) {
             $query->andWhere($query->newExpr()->isNull($field));
         }
     }
@@ -210,10 +212,9 @@ class TrashBehavior extends Behavior
      */
     public function findWithTrashed(Query $query, array $options)
     {
-        return $query->where(['OR' => [
-            $query->newExpr()->isNotNull($this->getTrashField()),
-            $query->newExpr()->isNull($this->getTrashField()),
-        ]]);
+        return $query->applyOptions([
+            'skipAddTrashCondition' => true
+        ]);
     }
 
     /**


### PR DESCRIPTION
This greatly improves load times when used with a MySQL backend. For some reason, MySQL ignores indexes when using `field IS NULL OR field IS NOT NULL`. For large tables, this results in long load times (we've seen samples of 3 minutes and up). Removing this kinda strange statement will resulted in way faster queries (~5 ms).