### PR TITLE
Allow full qualified namespace behavior

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -368,7 +368,7 @@ class TrashBehavior extends Behavior
     protected function _isRecursable(Association $association, Table $table): bool
     {
         if (
-            $association->getTarget()->hasBehavior('Trash')
+            ($association->getTarget()->hasBehavior('Trash') || $association->getTarget()->hasBehavior('Muffin\Trash\Model\Behavior\TrashBehavior'))
             && $association->isOwningSide($table)
             && $association->getDependent()
             && $association->getCascadeCallbacks()

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -17,6 +17,7 @@ use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use InvalidArgumentException;
+use Muffin\Trash\Model\Behavior\TrashBehavior;
 use RuntimeException;
 
 /**
@@ -368,7 +369,7 @@ class TrashBehavior extends Behavior
     protected function _isRecursable(Association $association, Table $table): bool
     {
         if (
-            ($association->getTarget()->hasBehavior('Trash') || $association->getTarget()->hasBehavior('Muffin\Trash\Model\Behavior\TrashBehavior'))
+            ($association->getTarget()->hasBehavior('Trash') || $association->getTarget()->hasBehavior(TrashBehavior::class))
             && $association->isOwningSide($table)
             && $association->getDependent()
             && $association->getCascadeCallbacks()

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -17,7 +17,6 @@ use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use InvalidArgumentException;
-use Muffin\Trash\Model\Behavior\TrashBehavior;
 use RuntimeException;
 
 /**
@@ -369,7 +368,7 @@ class TrashBehavior extends Behavior
     protected function _isRecursable(Association $association, Table $table): bool
     {
         if (
-            ($association->getTarget()->hasBehavior('Trash') || $association->getTarget()->hasBehavior(TrashBehavior::class))
+            ($association->getTarget()->hasBehavior('Trash') || $association->getTarget()->hasBehavior(static::class))
             && $association->isOwningSide($table)
             && $association->getDependent()
             && $association->getCascadeCallbacks()


### PR DESCRIPTION
When adding the behavior with the `::class` reference, the behavior is not picked up by the `_isRecursable` method.

```
use Muffin\Trash\Model\Behavior\TrashBehavior;

$this->addBehavior(TrashBehavior::class);
```