### PR TITLE
Improve beforeDelete event error handling

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -103,7 +103,7 @@ class TrashBehavior extends Behavior
     public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
         if (!$this->trash($entity, $options->getArrayCopy())) {
-            throw new RuntimeException();
+            return false;
         }
 
         $event->stopPropagation();

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -97,7 +97,7 @@ class TrashBehavior extends Behavior
      * @param \Cake\Event\Event $event The beforeDelete event that was fired.
      * @param \Cake\Datasource\EntityInterface $entity The entity to be deleted.
      * @param \ArrayObject $options Options.
-     * @return true
+     * @return bool
      * @throws \RuntimeException if fails to mark entity as `trashed`.
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -180,7 +180,6 @@ class TrashBehaviorTest extends TestCase
                 $event->setResult(false);
                 $event->stopPropagation();
             }
-
         );
 
         $result = $this->Articles->delete($article);

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -175,7 +175,7 @@ class TrashBehaviorTest extends TestCase
         $this->Articles->getEventManager()->on(
             'Model.beforeSave',
             [],
-            function (Event $event, EntityInterface $entity, ArrayObject $options) use (&$hasDeleteOptionsBefore) {
+            function (Event $event, EntityInterface $entity, ArrayObject $options) {
                 $entity->setError('id', 'Save aborted');
                 $event->setResult(false);
                 $event->stopPropagation();

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -11,7 +11,6 @@ use Cake\Event\Event;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Muffin\Trash\Model\Behavior\TrashBehavior;
@@ -187,7 +186,6 @@ class TrashBehaviorTest extends TestCase
         $this->assertFalse($result);
         $this->assertArrayHasKey('id', $article->getErrors());
     }
-
 
     /**
      * Tests that the options passed to the `delete()` method are being passed on into

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -164,6 +164,33 @@ class TrashBehaviorTest extends TestCase
     }
 
     /**
+     * Test the beforeDelete callback.
+     *
+     * @return void
+     */
+    public function testBeforeDeleteAbort()
+    {
+        $article = $this->Articles->get(1);
+
+        $this->Articles->getEventManager()->on(
+            'Model.beforeSave',
+            [],
+            function (Event $event, EntityInterface $entity, ArrayObject $options) use (&$hasDeleteOptionsBefore) {
+                $entity->setError('id', 'Save aborted');
+                $event->setResult(false);
+                $event->stopPropagation();
+            }
+
+        );
+
+        $result = $this->Articles->delete($article);
+
+        $this->assertFalse($result);
+        $this->assertArrayHasKey('id', $article->getErrors());
+    }
+
+
+    /**
      * Tests that the options passed to the `delete()` method are being passed on into
      * the cascading delete process.
      *


### PR DESCRIPTION
Return false instead of throwing an exception if save fails to allow other listeners to abort the update with proper error handling.