### PR TITLE
Added support for skipping soft-delete on beforeDelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ $this->addBehavior('Muffin/Trash.Trash', [
 ]);
 ```
 
+or use the purge option:
+
+```php
+$table->delete($entity, ['purge' => true]);
+```
+
 ### Cascading deletion
 
 If you'd like to have related records marked as trashed when deleting a parent

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -102,6 +102,10 @@ class TrashBehavior extends Behavior
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
+        if ($options->offsetExists('purge') && $options['purge'] === true) {
+            return true;
+        }
+
         if (!$this->trash($entity, $options->getArrayCopy())) {
             return false;
         }

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -188,6 +188,20 @@ class TrashBehaviorTest extends TestCase
     }
 
     /**
+     * Test the beforeDelete callback with the purge option
+     *
+     * @return void
+     */
+    public function testBeforeDeletePurge()
+    {
+        $article = $this->Articles->get(1);
+        $result = $this->Articles->delete($article, ['purge' => true]);
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $this->Articles->find('withTrashed'));
+    }
+
+    /**
      * Tests that the options passed to the `delete()` method are being passed on into
      * the cascading delete process.
      *


### PR DESCRIPTION
Useful when you want to mostly soft-delete but not always.

Playing with event handlers is not an option because we automatically enable the behavior for all tables but we want to skip soft-delete on very specific situations.