### PR TITLE
Ability to disable cascading for trash/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ item, you can just attach the behavior to the related table classes, and set the
 This works on relationships where the item being deleted in the owning side of
 the relationship. Which means that the related table should contain the foreign key.
 
-If you want to cascade normal (purge) deletion, but not to cascade trash/restore then:
+If you don't want to cascade on trash:
 ```php
 // in the initialize() method
 $this->addBehavior('Muffin/Trash.Trash', [
-    'cascadeTrashAndRestore' => false,
+    'cascadeOnTrash' => false,
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ item, you can just attach the behavior to the related table classes, and set the
 This works on relationships where the item being deleted in the owning side of
 the relationship. Which means that the related table should contain the foreign key.
 
+If you want to cascade normal (purge) deletion, but not to cascade trash/restore then:
+```php
+// in the initialize() method
+$this->addBehavior('Muffin/Trash.Trash', [
+    'cascadeTrashAndRestore' => false,
+]);
+```
+
 ### Custom Finders
 
 - **onlyTrashed** - helps getting only those trashed records.

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -43,6 +43,7 @@ class TrashBehavior extends Behavior
             'Model.beforeDelete',
             'Model.beforeFind',
         ],
+        'cascadeTrashAndRestore' => true,
     ];
 
     /**
@@ -388,6 +389,7 @@ class TrashBehavior extends Behavior
                 $association->getTarget()->hasBehavior('Trash')
                 || $association->getTarget()->hasBehavior(static::class)
             )
+            && $this->getConfig('cascadeTrashAndRestore')
             && $association->isOwningSide($table)
             && $association->getDependent()
             && $association->getCascadeCallbacks();

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -43,7 +43,7 @@ class TrashBehavior extends Behavior
             'Model.beforeDelete',
             'Model.beforeFind',
         ],
-        'cascadeTrashAndRestore' => true,
+        'cascadeOnTrash' => true,
     ];
 
     /**
@@ -146,10 +146,12 @@ class TrashBehavior extends Behavior
             }
         }
 
-        $associations = $this->_table->associations()->getByType(['HasOne', 'HasMany']);
-        foreach ($associations as $association) {
-            if ($this->_isRecursable($association, $this->_table)) {
-                $association->cascadeDelete($entity, ['_primary' => false] + $options);
+        if ($this->getConfig('cascadeOnTrash')) {
+            $associations = $this->_table->associations()->getByType(['HasOne', 'HasMany']);
+            foreach ($associations as $association) {
+                if ($this->_isRecursable($association, $this->_table)) {
+                    $association->cascadeDelete($entity, ['_primary' => false] + $options);
+                }
             }
         }
 
@@ -389,7 +391,6 @@ class TrashBehavior extends Behavior
                 $association->getTarget()->hasBehavior('Trash')
                 || $association->getTarget()->hasBehavior(static::class)
             )
-            && $this->getConfig('cascadeTrashAndRestore')
             && $association->isOwningSide($table)
             && $association->getDependent()
             && $association->getCascadeCallbacks();

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -539,7 +539,7 @@ class TrashBehaviorTest extends TestCase
         $association->setCascadeCallbacks(true);
 
         // disable cascade trash/restore
-        $this->Articles->behaviors()->get('Trash')->setConfig('cascadeTrashAndRestore', false);
+        $this->Articles->behaviors()->get('Trash')->setConfig('cascadeOnTrash', false);
 
         $article = $this->Articles->get(1);
         $this->Articles->trash($article);

--- a/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TrashBehaviorTest.php
@@ -526,6 +526,38 @@ class TrashBehaviorTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $article->comments[0]->trashed);
     }
 
+    /**
+     * When cascadeTrashAndRestore = false
+     * Ensure that when trashing it will not cascade into related dependent records
+     *
+     * @return void
+     */
+    public function testDisabledCascadingForTrash()
+    {
+        $association = $this->Articles->Comments;
+        $association->setDependent(true);
+        $association->setCascadeCallbacks(true);
+
+        // disable cascade trash/restore
+        $this->Articles->behaviors()->get('Trash')->setConfig('cascadeTrashAndRestore', false);
+
+        $article = $this->Articles->get(1);
+        $this->Articles->trash($article);
+
+        $article = $this->Articles->find('withTrashed')
+            ->where(['Articles.id' => 1])
+            ->contain(['Comments' => [
+                'finder' => 'withTrashed',
+            ]])
+            ->first();
+
+        $this->assertNotEmpty($article->trashed);
+        $this->assertInstanceOf(DateTime::class, $article->trashed);
+
+        // expect not trashed
+        $this->assertEmpty($article->comments[0]->trashed);
+    }
+
     public function testCascadingUntrashOptionsArePassedToSave()
     {
         $association = $this->Articles->Comments;


### PR DESCRIPTION
Pull request give the ability to disable cascading for trash/restore only and can still cascade the normal delete/purge.

----
We decided to only cascade deletion (with cascade enabled for audit log) , but never cascade trash or restore.

The reason for that is, that if you restore entity in hasMany relation, you might not want to restore 'child' entities that was intentionally trashed before you accidentally trash and restore the 'parent'.

For example, you have Users hasMany UserNotes.
User create 2 notes, User trashes one of the note.
Admin trashes User (it does trash the one not yet trashed note), then admin restore User (for some reason), the code can't restore the UserNotes to the 'previous state' like you would expect of "restore" to do, it will restore `Both` UserNotes even if one of the notes needs to be still trashed.

So you want to delete UserNotes if you delete User, but you don't want to trash/restore User notes when you trash/restore User.