### PR TITLE
Improve performance on queries with skipAddTrashCondition.

### DIFF
--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -180,15 +180,14 @@ class TrashBehavior extends Behavior
      */
     public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void
     {
-        $option = $query->getOptions();
-        if (!empty($option['skipAddTrashCondition'])) {
+        if (!empty($options['skipAddTrashCondition'])) {
             return;
         }
 
         $field = $this->getTrashField();
 
         if ($this->shouldAddTrashCondition($query, $field)) {
-            $query->andWhere($query->newExpr()->isNull($field));
+            $query->andWhere([$field . ' IS' => null]);
         }
     }
 
@@ -237,7 +236,9 @@ class TrashBehavior extends Behavior
      */
     public function findOnlyTrashed(SelectQuery $query, array $options): SelectQuery
     {
-        return $query->andWhere($query->newExpr()->isNotNull($this->getTrashField()));
+        return $query
+            ->applyOptions(['skipAddTrashCondition' => true])
+            ->andWhere($query->newExpr()->isNotNull($this->getTrashField()));
     }
 
     /**

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -181,7 +181,7 @@ class TrashBehavior extends Behavior
     public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void
     {
         $option = $query->getOptions();
-        if (empty($option['skipAddTrashCondition'])) {
+        if (!empty($option['skipAddTrashCondition'])) {
             return;
         }
 

--- a/src/Model/Behavior/TrashBehavior.php
+++ b/src/Model/Behavior/TrashBehavior.php
@@ -187,7 +187,7 @@ class TrashBehavior extends Behavior
 
         $field = $this->getTrashField();
 
-        if ($this->addTrashCondition($query, $field)) {
+        if ($this->shouldAddTrashCondition($query, $field)) {
             $query->andWhere($query->newExpr()->isNull($field));
         }
     }
@@ -199,7 +199,7 @@ class TrashBehavior extends Behavior
      * @param string $field Trash field
      * @return bool
      */
-    protected function addTrashCondition(SelectQuery $query, string $field): bool
+    protected function shouldAddTrashCondition(SelectQuery $query, string $field): bool
     {
         $addCondition = true;
 


### PR DESCRIPTION
- Do not scan the query if we know we will not add the condition anyway.
- Move query scanning to a function to allow users to override/skip it based on their requirements.